### PR TITLE
fix: add lambda integration to avoid flag redefined error

### DIFF
--- a/pkg/integration/lambda.go
+++ b/pkg/integration/lambda.go
@@ -1,0 +1,48 @@
+package integration
+
+import (
+	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/log"
+	"github.com/spf13/viper"
+)
+
+func NewLambdaIntegration(
+	buildInfo *BuildInfo,
+	appName string,
+	labsIntegrationOpts ...LabsIntegrationOpt,
+) (*LabsIntegration, error) {
+	// We don't setup/process command line flags since we are running as a
+	// lambda.
+
+	// Load configuration with viper
+	// We have to do this prior to setting up the APM app because the license
+	// key may be in the config.
+	err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Now that the config is loaded, setup logging
+	err = setupLogging(log.RootLogger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup APM
+	app, err := setupApm(appName, log.RootLogger)
+	if err != nil {
+		return nil, err
+	}
+
+	defer log.Debugf("starting %s integration", buildInfo.Name)
+
+	// Create the integration
+	return newLabsIntegration(
+		buildInfo,
+		app,
+		nil,		// this is not an infra integration
+		log.RootLogger,
+		false,		// can't run as service when running as a lambda
+		viper.GetBool("dry_run"),
+		labsIntegrationOpts,
+	)
+}


### PR DESCRIPTION
## Fixes
* Don't parse command line args when running as Lambda to avoid "/var/task/bootstrap flag redefined: verbose" error