### PR TITLE
feat: automatically set http user agent; move buildinfo to build package; refactor to remove root package dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ config.yml
 dist/
 cf-params.json
 __tools/
+main

--- a/cmd/example1/main.go
+++ b/cmd/example1/main.go
@@ -12,20 +12,9 @@ import (
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/pipeline"
 )
 
-var (
-	/* Args below are populated via ldflags at build time */
-	gIntegrationID      = "com.newrelic.labs.test"
-	gIntegrationName    = "Labs SDK Example 1"
-	gIntegrationVersion = "0.1.0"
-	gGitCommit          = ""
-	gBuildDate          = ""
-	gBuildInfo			= integration.BuildInfo{
-		Id:        gIntegrationID,
-		Name:      gIntegrationName,
-		Version:   gIntegrationVersion,
-		GitCommit: gGitCommit,
-		BuildDate: gBuildDate,
-	}
+const (
+	INTEGRATION_ID = "com.newrelic.labs.sdk.test1"
+	INTEGRATION_NAME = "Labs SDK Example 1"
 )
 
 type testComponent2 struct {
@@ -93,17 +82,17 @@ func (t *testComponent2) PollLogs(ctx context.Context, writer chan <- model.Log)
 }
 
 func main() {
-	// Create a new background context to us
+	// Create a new background context to use
 	ctx := context.Background()
 
 	// Create the integration with options
 	i, err := integration.NewStandaloneIntegration(
-		&gBuildInfo,
-		gBuildInfo.Name,
+		INTEGRATION_NAME,
+		INTEGRATION_ID,
+		INTEGRATION_NAME,
 		integration.WithLicenseKey(),
 		integration.WithApiKey(),
 		integration.WithAccountId(),
-		integration.WithClient(),
 		integration.WithEvents(ctx),
 		integration.WithLogs(ctx),
 	)
@@ -111,7 +100,15 @@ func main() {
 
 	// Create application components (receivers, processors, exporters)
 	component := &testComponent2{}
-	newRelicExporter := exporters.NewNewRelicExporter("newrelic", i)
+	newRelicExporter := exporters.NewNewRelicExporter(
+		"newrelic",
+		INTEGRATION_NAME,
+		INTEGRATION_ID,
+		i.NrClient,
+		i.GetLicenseKey(),
+		i.GetRegion(),
+		i.DryRun,
+	)
 
 	// Create one or more pipelines
 	mp := pipeline.NewMetricsPipeline()

--- a/pkg/integration/build/build.go
+++ b/pkg/integration/build/build.go
@@ -1,0 +1,24 @@
+package build
+
+type BuildInfo struct {
+	Version   			string
+	Commit 				string
+	Date 				string
+}
+
+var (
+	gBuildVersion 		string
+	gBuildCommit        string
+	gBuildDate          string
+	gBuildInfo			BuildInfo
+)
+
+func init() {
+	gBuildInfo.Version = gBuildVersion
+	gBuildInfo.Commit = gBuildCommit
+	gBuildInfo.Date = gBuildDate
+}
+
+func GetBuildInfo() BuildInfo {
+	return gBuildInfo
+}

--- a/pkg/integration/exporters/nri.go
+++ b/pkg/integration/exporters/nri.go
@@ -8,23 +8,30 @@ import (
 
 	nriSdkMetrics "github.com/newrelic/infra-integrations-sdk/v4/data/metric"
 	nriSdk "github.com/newrelic/infra-integrations-sdk/v4/integration"
-	"github.com/newrelic/newrelic-labs-sdk/pkg/integration"
+	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/build"
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/log"
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/model"
 )
 
 type NewRelicInfraExporter struct {
 	id				string
-	buildInfo		*integration.BuildInfo
+	integrationName	string
+	integrationId	string
+	buildInfo		build.BuildInfo
 	i 				*nriSdk.Integration
 	entity			*nriSdk.Entity
 }
 
-func NewNewRelicInfraExporter(id string, li *integration.LabsIntegration) *NewRelicInfraExporter {
+func NewNewRelicInfraExporter(
+	id, integrationName, integrationId string,
+	i *nriSdk.Integration,
+) *NewRelicInfraExporter {
 	return &NewRelicInfraExporter{
 		id,
-		li.BuildInfo,
-		li.Integration,
+		integrationName,
+		integrationId,
+		build.GetBuildInfo(),
+		i,
 		nil,
 	}
 }
@@ -94,10 +101,10 @@ func (e *NewRelicInfraExporter) ExportLogs(
 
 func (e *NewRelicInfraExporter) addAttributes(metric *model.Metric, nriMetric nriSdkMetrics.Metric) {
 
-	nriMetric.AddDimension("instrumentation.name", e.buildInfo.Name)
+	nriMetric.AddDimension("instrumentation.name", e.integrationName)
 	nriMetric.AddDimension("instrumentation.provider", "newrelic-labs")
 	nriMetric.AddDimension("instrumentation.version", e.buildInfo.Version)
-	nriMetric.AddDimension("collector.name", e.buildInfo.Id)
+	nriMetric.AddDimension("collector.name", e.integrationId)
 
 	for k, v := range metric.Attributes {
 		switch val := v.(type) {

--- a/pkg/integration/infra.go
+++ b/pkg/integration/infra.go
@@ -4,6 +4,7 @@ import (
 	nriSdkArgs "github.com/newrelic/infra-integrations-sdk/v4/args"
 	nriSdk "github.com/newrelic/infra-integrations-sdk/v4/integration"
 	nriSdkLog "github.com/newrelic/infra-integrations-sdk/v4/log"
+	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/build"
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/log"
 	"github.com/spf13/viper"
 )
@@ -20,18 +21,18 @@ var (
 )
 
 func NewInfraIntegration(
-	buildInfo *BuildInfo,
+	name, id string,
 	labsIntegrationOpts ...LabsIntegrationOpt,
 ) (*LabsIntegration, error) {
 	// Create the native infra integration
-	i, err := createInfraIntegration(buildInfo, log.RootLogger)
+	i, err := createInfraIntegration(id, log.RootLogger)
 	if err != nil {
 		return nil, err
 	}
 
 	// Maybe show the version info
 	if infraArgs.ShowVersion {
-		showVersionAndExit(buildInfo)
+		showVersionAndExit(name)
 	}
 
 	// Bind custom flag information to viper
@@ -51,10 +52,11 @@ func NewInfraIntegration(
 		return nil, err
 	}
 
-	defer log.Debugf("starting %s integration", buildInfo.Name)
+	defer log.Debugf("starting %s integration", name)
 
 	return newLabsIntegration(
-		buildInfo,
+		name,
+		id,
 		nil,
 		i,
 		log.RootLogger,
@@ -65,12 +67,12 @@ func NewInfraIntegration(
 }
 
 func createInfraIntegration(
-	buildInfo *BuildInfo,
+	id string,
 	logger nriSdkLog.Logger,
 ) (*nriSdk.Integration, error) {
 	return nriSdk.New(
-		buildInfo.Id,
-		buildInfo.Version,
+		id,
+		build.GetBuildInfo().Version,
 		nriSdk.Args(&infraArgs),
 		nriSdk.Logger(logger),
 	)

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/newrelic/go-agent/v3/newrelic"
 	nriSdk "github.com/newrelic/infra-integrations-sdk/v4/integration"
 	nrClient "github.com/newrelic/newrelic-client-go/newrelic"
+	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/build"
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/log"
 	"github.com/newrelic/newrelic-labs-sdk/pkg/integration/pipeline"
 
@@ -28,18 +29,17 @@ const (
 )
 
 type (
-	BuildInfo struct {
-		Id        string
-		Name      string
-		Version   string
-		GitCommit string
-		BuildDate string
-	}
 	LabsIntegrationOpt func(li *LabsIntegration) error
 )
 
+// @TODO: connectors Request() methods should take a context
+// @TODO: support custom tags via config
+// @TODO: connectors should take a Context
+
 type LabsIntegration struct {
-	BuildInfo		*BuildInfo
+	Name			string
+	Id				string
+	BuildInfo		build.BuildInfo
 	App           	*newrelic.Application
 	Integration   	*nriSdk.Integration
 	Logger        	*logrus.Logger
@@ -57,7 +57,7 @@ type LabsIntegration struct {
 }
 
 func newLabsIntegration(
-	buildInfo *BuildInfo,
+	name, id string,
 	app *newrelic.Application,
 	integration *nriSdk.Integration,
 	logger *logrus.Logger,
@@ -66,7 +66,9 @@ func newLabsIntegration(
 	labsIntegrationOpts []LabsIntegrationOpt,
 ) (*LabsIntegration, error) {
 	li := &LabsIntegration{
-		BuildInfo: buildInfo,
+		Name: name,
+		Id: id,
+		BuildInfo: build.GetBuildInfo(),
 		App: app,
 		Integration: integration,
 		Logger: logger,
@@ -116,16 +118,18 @@ func (i *LabsIntegration) Run(ctx context.Context) error {
 	return nil
 }
 
-func showVersionAndExit(buildInfo *BuildInfo) {
+func showVersionAndExit(integrationName string) {
+	buildInfo := build.GetBuildInfo()
+
 	// Show the version
 	fmt.Printf(
 		"%s Version: %s, Platform: %s, GoVersion: %s, GitCommit: %s, BuildDate: %s\n",
-		buildInfo.Name,
+		integrationName,
 		buildInfo.Version,
 		fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 		runtime.Version(),
-		buildInfo.GitCommit,
-		buildInfo.BuildDate,
+		buildInfo.Commit,
+		buildInfo.Date,
 	)
 	os.Exit(0)
 }

--- a/pkg/integration/lambda.go
+++ b/pkg/integration/lambda.go
@@ -6,8 +6,7 @@ import (
 )
 
 func NewLambdaIntegration(
-	buildInfo *BuildInfo,
-	appName string,
+	name, id, appName string,
 	labsIntegrationOpts ...LabsIntegrationOpt,
 ) (*LabsIntegration, error) {
 	// We don't setup/process command line flags since we are running as a
@@ -33,11 +32,12 @@ func NewLambdaIntegration(
 		return nil, err
 	}
 
-	defer log.Debugf("starting %s integration", buildInfo.Name)
+	defer log.Debugf("starting %s integration", name)
 
 	// Create the integration
 	return newLabsIntegration(
-		buildInfo,
+		name,
+		id,
 		app,
 		nil,		// this is not an infra integration
 		log.RootLogger,

--- a/pkg/integration/standalone.go
+++ b/pkg/integration/standalone.go
@@ -13,15 +13,14 @@ import (
 )
 
 func NewStandaloneIntegration(
-	buildInfo *BuildInfo,
-	appName string,
+	name, id, appName string,
 	labsIntegrationOpts ...LabsIntegrationOpt,
 ) (*LabsIntegration, error) {
 	// Parse args
 	parseStandaloneArgs()
 
 	// Maybe show the version info
-	err := maybeShowVersion(buildInfo)
+	err := maybeShowVersion(name)
 	if err != nil {
 		return nil, err
 	}
@@ -46,11 +45,12 @@ func NewStandaloneIntegration(
 		return nil, err
 	}
 
-	defer log.Debugf("starting %s integration", buildInfo.Name)
+	defer log.Debugf("starting %s integration", name)
 
 	// Create the integration
 	return newLabsIntegration(
-		buildInfo,
+		name,
+		id,
 		app,
 		nil,
 		log.RootLogger,
@@ -60,14 +60,14 @@ func NewStandaloneIntegration(
 	)
 }
 
-func maybeShowVersion(buildInfo *BuildInfo) error {
+func maybeShowVersion(integrationName string) error {
 	version, err := pflag.CommandLine.GetBool("version")
 	if err != nil {
 		return err
 	}
 
 	if version {
-		showVersionAndExit(buildInfo)
+		showVersionAndExit(integrationName)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

* Automatically set user agent for HTTP connector
* Move `BuildInfo` into it's own package to remove dependencies on root package
* Remove other dependencies on root package

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
