### PR TITLE
chore: update go.mod to use /v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/newrelic-labs-sdk
+module github.com/newrelic/newrelic-labs-sdk/v2
 
 go 1.20
 


### PR DESCRIPTION
## Updates
* Update `go.mod` module path to use `v2`